### PR TITLE
Added a Related Reading section to list supplementary articles/links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ From the KRACK <a href="https://www.krackattacks.com/">website</a>:
 * Adversary can not recover WPA password.
 * Adversary can not inject packets. *(AES-CCMP ONLY)*
 
+## Related Reading
+* https://blog.cryptographyengineering.com/2017/10/16/falling-through-the-kracks/
+* https://www.reddit.com/r/KRaCK/comments/76pjf8/krack_megathread_check_back_often_for_updated/
+
 
 # Vendor Response
 


### PR DESCRIPTION
So far, I've [seen](https://news.ycombinator.com/item?id=15483421) a good TL;DR blog post and a megathread in the official krack subreddit. Thought it would be best if they were listed under a "Related Reading" section.