### PR TITLE
Reformat for better readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ From the KRACK <a href="https://www.krackattacks.com/">website</a>:
 * Adversary can force the client into using a predictable all-zero encryption key. *(ANDROID 6.0+ and LINUX)*
 
 
-### Attacks that can not be made (できないこと)
+### Attacks that cannot be made (できないこと)
 * Adversary can not recover WPA password.
 * Adversary can not inject packets. *(AES-CCMP ONLY)*
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,25 @@
-# *K*ey *R*einstallation *A*tta*ck*s (KRACK)
+# KRACK: (K)ey (R)einstallation (A)tta(ck)
 
 From the KRACK <a href="https://www.krackattacks.com/">website</a>:
 > In a key reinstallation attack, the adversary tricks a victim into reinstalling an already-in-use key. This is achieved by manipulating and replaying cryptographic handshake messages. When the victim reinstalls the key, associated parameters such as the incremental transmit packet number (i.e. nonce) and receive packet number (i.e. replay counter) are reset to their initial value. Essentially, to guarantee security, a key should only be installed and used once. Unfortunately, we found this is not guaranteed by the WPA2 protocol. By manipulating cryptographic handshakes, we can abuse this weakness in practice.
 
-## Unless a known patch has been applied, assume that all WPA2 enabled Wi-fi devices are vulnerable.
+***Unless a known patch has been applied, assume that all WPA2 enabled Wi-fi devices are vulnerable.***
 
-## Attacks that can be made (できること)
+
+### Attacks that can be made (できること)
 * Adversary can decrypt arbitrary packets.
   * This allows an adversary to obtain the TCP sequence numbers of a connection, and <a href="https://en.wikipedia.org/wiki/TCP_sequence_prediction_attack">hijack TCP connections</a>.
 * Adversary can replay broadcast and multicast frames.
 * Adversary can both decrypt and inject arbitrary packets. *(TKIP or GCMP ONLY)*
 * Adversary can force the client into using a predictable all-zero encryption key. *(ANDROID 6.0+ and LINUX)*
 
-## Attacks that can not be made (できないこと)
+
+### Attacks that can not be made (できないこと)
 * Adversary can not recover WPA password.
 * Adversary can not inject packets. *(AES-CCMP ONLY)*
 
-## Related Reading
+
+### Related Reading
 * https://blog.cryptographyengineering.com/2017/10/16/falling-through-the-kracks/
 * https://www.reddit.com/r/KRaCK/comments/76pjf8/krack_megathread_check_back_often_for_updated/
 


### PR DESCRIPTION
* acronym emphasis via italics not very visible/obvious in H1
* H2 newlines unnecessary for some, as they are not major sections - changed to H3
* other small fixes

