### PR TITLE
Update FreeBSD with announcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ From the KRACK <a href="https://www.krackattacks.com/">website</a>:
 | Fedora | https://bodhi.fedoraproject.org/updates/wpa_supplicant-2.6-11.fc27 | Status: Fixed Release: Pending (* Manual installation is possible) | 2017-10-17 | 2017-10-17 |  |
 | FortiNet | http://docs.fortinet.com/uploaded/files/3961/fortiap-v5.6.1-release-notes.pdf | FortiAP 5.6.1 is no longer vulnerable to the following CVE Reference:...CVE-2017-13077CVE-2017-13078CVE-2017-13079CVE-2017-13080CVE-2017-13081CVE-2017-13082 | 2017-10-16 | 2017-10-16 |  |
 | Foundry Brocade | No Known Official Response | N/A | 2017-10-17 | 2017-10-17 |  |
-| FreeBSD Project | No Known Official Response | N/A | 2017-10-16 | 2017-10-16 | 28 Aug 2017 |
+| FreeBSD Project | https://lists.freebsd.org/pipermail/freebsd-announce/2017-October/001805.html | Patch in development | 2017-10-16 | 2017-10-16 | 28 Aug 2017 (?) |
 | Google | No Known Official Response | N/A | 2017-10-16 | 2017-10-16 |  |
 | Hewlett Packard Enterprise | No Known Official Response | N/A | 2017-10-17 | 2017-10-17 |  |
 | Honeywell | No Known Official Response | N/A | 2017-10-16 | 2017-10-16 |  |


### PR DESCRIPTION
I'm looking for confirmation on the "Date notified by CERT" for FreeBSD,
and have annotated it with (?) for now.