### PR TITLE
Update Aruba

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ From the KRACK <a href="https://www.krackattacks.com/">website</a>:
 |--------|-----------------|----------------|-----------------------|
 | Arch Linux | X |  |  |
 | Arista |  |  | X |
-| Aruba | X |  |  |
+| Aruba | [X](http://www.arubanetworks.com/assets/alert/ARUBA-PSA-2017-007_FAQ_Rev-1.pdf) |  |  |
 | Asus |  | X | X |
 | Cisco |  | X |  |
 | DD-WRT | X |  |  |


### PR DESCRIPTION
Q: Which versions of ArubaOS software contain the fixes?
A: The vulnerabilities have been fixed in the following ArubaOS patch releases, which are all available for download immediately:
• 6.3.1.25
• 6.4.4.16
• 6.5.1.9
• 6.5.3.3
• 6.5.4.2
• 8.1.0.4