### PR TITLE
SM-G900F: Result of personal verification

### DIFF
--- a/ANDROID_S-Z.md
+++ b/ANDROID_S-Z.md
@@ -1263,7 +1263,7 @@
 | Samsung | Galaxy S5 | k3g | SM-G900H |  |  | 2017-10-19 | 2017-10-19 |
 | Samsung | Galaxy S5 | klte | SM-G9008W |  |  | 2017-10-19 | 2017-10-19 |
 | Samsung | Galaxy S5 | klte | SM-G9009W |  |  | 2017-10-19 | 2017-10-19 |
-| Samsung | Galaxy S5 | klte | SM-G900F |  |  | 2017-10-19 | 2017-10-19 |
+| Samsung | Galaxy S5 | klte | SM-G900F |  | Android 6.0.1, security patch level 2017-07-01: vulnerable to 4-way handshake and group key attack | 2017-10-19 | 2017-12-30 |
 | Samsung | Galaxy S5 | klte | SM-G900FQ |  |  | 2017-10-19 | 2017-10-19 |
 | Samsung | Galaxy S5 | klte | SM-G900I |  |  | 2017-10-19 | 2017-10-19 |
 | Samsung | Galaxy S5 | klte | SM-G900M |  |  | 2017-10-19 | 2017-10-19 |


### PR DESCRIPTION
Using [M. Vanhoef's  set of scripts](https://github.com/vanhoefm/krackattacks-scripts) I was able to check a Samsung SM-G900F for vulnerability with most recent security patches (apparently they won't get more than this) - and yes, it is both vulnerable to the 4-way handshake issue and the group key attack. 
I have documented the result accordingly.

@kristate: Are you willing to accept merges like this, documenting the state of vulernability of each corresponding device?